### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/.github/ISSUE_TEMPLATE/phpcs-failure.md
+++ b/.github/ISSUE_TEMPLATE/phpcs-failure.md
@@ -26,6 +26,6 @@ The code does not meet WordPress coding standards as defined by PHPCS.
 
 **Resources:**
 - [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/)
-- [PHP CodeSniffer Documentation](https://github.com/squizlabs/PHP_CodeSniffer)
+- [PHP CodeSniffer Documentation](https://github.com/PHPCSStandards/PHP_CodeSniffer)
 
 This issue was automatically created by the CI/CD pipeline.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -276,7 +276,7 @@ This project follows [Semantic Versioning](https://semver.org/):
 - [WordPress Security Handbook](https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/)
 
 ### Tools
-- [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)
+- [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer)
 - [PHPStan](https://phpstan.org/)
 - [WordPress Plugin Check](https://wordpress.org/plugins/plugin-check/)
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932